### PR TITLE
nondet in backwards summaries

### DIFF
--- a/src/domains/template_generator_base.cpp
+++ b/src/domains/template_generator_base.cpp
@@ -322,6 +322,17 @@ void template_generator_baset::add_var(const domaint::vart &var,
   }
 }
 
+void template_generator_baset::add_vars(const std::set<exprt> &vars_to_add, 
+			     const domaint::guardt &pre_guard, 
+			     const domaint::guardt &post_guard,
+			     const domaint::kindt &kind,
+			     domaint::var_specst &var_specs)
+{
+  for(std::set<exprt>::const_iterator it = vars_to_add.begin();
+      it != vars_to_add.end(); it++) 
+    add_var(*it,pre_guard,post_guard,kind,var_specs);
+}
+
 void template_generator_baset::add_vars(const local_SSAt::var_listt &vars_to_add, 
 			     const domaint::guardt &pre_guard, 
 			     const domaint::guardt &post_guard,

--- a/src/domains/template_generator_base.h
+++ b/src/domains/template_generator_base.h
@@ -74,6 +74,11 @@ protected:
 	       domaint::guardt post_guard,
 	       const domaint::kindt &kind,
 	       domaint::var_specst &var_specs);
+  void add_vars(const std::set<exprt> &vars_to_add, 			    
+		const domaint::guardt &pre_guard, 
+		const domaint::guardt &post_guard,
+		const domaint::kindt &kind,
+		domaint::var_specst &var_specs);
   void add_vars(const var_listt &vars_to_add, 			    
 		const domaint::guardt &pre_guard, 
 		const domaint::guardt &post_guard,

--- a/src/domains/template_generator_summary.cpp
+++ b/src/domains/template_generator_summary.cpp
@@ -89,6 +89,13 @@ void template_generator_summaryt::collect_variables_inout(const local_SSAt &SSA,
   add_vars(SSA.globals_out,last_guard,last_guard,
 	   forward ? domaint::OUT : domaint::IN,
 	   var_specs);
+
+  // add nondets for backwards analysis
+  if(!forward)
+  {
+    add_vars(SSA.nondets,first_guard,first_guard,
+             domaint::OUT, var_specs);
+  }
 }
 
 /*******************************************************************\

--- a/src/domains/util.cpp
+++ b/src/domains/util.cpp
@@ -30,7 +30,7 @@ void extend_expr_types(exprt &expr)
     return;
   }
   if(expr.id()==ID_constant) return;
-  if(expr.id()==ID_symbol) return;
+  if(expr.id()==ID_symbol || expr.id()==ID_nondet_symbol) return;
   if(expr.id()==ID_index) return;
   if(expr.id()==ID_unary_minus)
   {
@@ -200,7 +200,7 @@ mp_integer simplify_const_int(const exprt &expr)
     assert(d!=0);
     return simplify_const_int(expr.op0())/d;  
   }
-  if(expr.id()==ID_symbol) 
+  if(expr.id()==ID_symbol || expr.id()==ID_nondet_symbol) 
   {
 #if 0
     std::cerr << "substituting default value for " << expr << std::endl;
@@ -279,7 +279,7 @@ ieee_floatt simplify_const_float(const exprt &expr)
     v1 /= v2;
     return v1; 
   }
-  if(expr.id()==ID_symbol)  //default value if not substituted in expr
+  if(expr.id()==ID_symbol || expr.id()==ID_nondet_symbol)  //default value if not substituted in expr
   {
     ieee_floatt v;
     v.make_zero();

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -144,7 +144,7 @@ Function: local_SSAt::get_nondet_vars
 
 void local_SSAt::get_nondet_vars(const exprt &expr)
 {
-  if(expr.id()==ID_nondet)
+  if(expr.id()==ID_nondet_symbol)
     nondets.insert(expr);
   else
     forall_operands(it, expr)

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -125,7 +125,57 @@ void local_SSAt::get_entry_exit_vars()
   goto_programt::const_targett 
     last = goto_function.body.instructions.end(); last--;
   get_globals(last,globals_out,true,true,last->function);
+
+  //get nondeterministic variables
+  get_nondet_vars();
 }
+
+/*******************************************************************\
+
+Function: local_SSAt::get_nondet_vars
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void local_SSAt::get_nondet_vars(const exprt &expr)
+{
+  if(expr.id()==ID_nondet)
+    nondets.insert(expr);
+  else
+    forall_operands(it, expr)
+      get_nondet_vars(*it);
+}
+
+void local_SSAt::get_nondet_vars()
+{
+  for(nodest::iterator n_it=nodes.begin(); 
+      n_it!=nodes.end(); n_it++)
+  {
+    for(nodet::equalitiest::const_iterator
+	  e_it=n_it->equalities.begin();
+	e_it!=n_it->equalities.end();
+	e_it++)
+      get_nondet_vars(*e_it);
+
+    for(nodet::constraintst::const_iterator
+	  c_it=n_it->constraints.begin();
+	c_it!=n_it->constraints.end();
+	c_it++)
+      get_nondet_vars(*c_it);
+
+    for(nodet::assertionst::const_iterator
+	  a_it=n_it->assertions.begin();
+	a_it!=n_it->assertions.end();
+	a_it++)
+      get_nondet_vars(*a_it);
+  }
+}
+
 
 /*******************************************************************\
 
@@ -1546,10 +1596,10 @@ void local_SSAt::nodet::output(
     out << "(E) " << from_expr(ns, "", *e_it) << "\n";
 
   for(constraintst::const_iterator
-      e_it=constraints.begin();
-      e_it!=constraints.end();
-      e_it++)
-    out << "(C) " << from_expr(ns, "", *e_it) << "\n";
+      c_it=constraints.begin();
+      c_it!=constraints.end();
+      c_it++)
+    out << "(C) " << from_expr(ns, "", *c_it) << "\n";
 
   for(assertionst::const_iterator
       a_it=assertions.begin();

--- a/src/ssa/local_ssa.h
+++ b/src/ssa/local_ssa.h
@@ -128,7 +128,8 @@ public:
   typedef std::list<symbol_exprt> var_listt;
   typedef std::set<symbol_exprt> var_sett;
   var_listt params;  
-  var_sett globals_in, globals_out;  
+  var_sett globals_in, globals_out;
+  std::set<exprt> nondets;  
 
   bool has_function_calls() const;
 
@@ -214,6 +215,9 @@ protected:
   void collect_custom_templates();
   replace_mapt template_newvars;
   exprt template_last_newvar;
+
+  void get_nondet_vars(const exprt &expr);
+  void get_nondet_vars();
 };
 
 std::vector<exprt> & operator <<

--- a/src/summarizer/summarizer_bw_cex_ai.cpp
+++ b/src/summarizer/summarizer_bw_cex_ai.cpp
@@ -137,6 +137,7 @@ void summarizer_bw_cex_ait::compute_summary_rec(
     summary.params = SSA.params;
     summary.globals_in = SSA.globals_in;
     summary.globals_out = SSA.globals_out;
+    summary.nondets = SSA.nondets;
   }
 
     // insert assertion
@@ -238,6 +239,7 @@ void summarizer_bw_cex_ait::do_summary(const function_namet &function_name,
 
   assert_postcond.push_back(postcondition);  //context
 
+  //TODO: add nondet variables from callees to summary.nondets
 
   // assumptions must hold
   for(local_SSAt::nodest::const_iterator 

--- a/src/summarizer/summarizer_bw_cex_concrete.cpp
+++ b/src/summarizer/summarizer_bw_cex_concrete.cpp
@@ -130,6 +130,7 @@ void summarizer_bw_cex_concretet::compute_summary_rec(
     summary.params = SSA.params;
     summary.globals_in = SSA.globals_in;
     summary.globals_out = SSA.globals_out;
+    summary.nondets = SSA.nondets;
   }
 
     // insert assertion
@@ -226,6 +227,8 @@ void summarizer_bw_cex_concretet::do_summary(
   bool assertion_flag;
   assertion_flag = ssa_inliner.get_summaries(SSA,call_site,false,assert_postcond,noassert_postcond,c); //backward summaries
   assert_postcond.push_back(postcondition);  //context
+
+  //TODO: add nondet variables from callees to summary.nondets
 
   //std::cout << "Assert Summary: " << from_expr(SSA.ns, "", conjunction(assert_postcond)) << "\n\n";
   //std::cout << "Noassert Summary: " << from_expr(SSA.ns, "", conjunction(noassert_postcond)) << "\n\n";
@@ -382,6 +385,13 @@ void summarizer_bw_cex_concretet::do_summary(
 
   for(local_SSAt::var_sett::const_iterator it = SSA.globals_out.begin();
       it != SSA.globals_out.end(); it++){
+    exprt summ_value = solver.get(*it);
+    if(!summ_value.is_nil())
+      var_values.push_back(equal_exprt(*it, summ_value));
+  }
+
+  for(std::set<exprt>::const_iterator it = summary.nondets.begin();
+      it != summary.nondets.end(); it++){
     exprt summ_value = solver.get(*it);
     if(!summ_value.is_nil())
       var_values.push_back(equal_exprt(*it, summ_value));

--- a/src/summarizer/summary.cpp
+++ b/src/summarizer/summary.cpp
@@ -42,6 +42,11 @@ void summaryt::output(std::ostream &out, const namespacet &ns) const
       it != globals_out.end(); it++)
     out << from_expr(ns,"",*it) << " ";
   out << std::endl;
+  out << "nondets: ";
+  for(summaryt::expr_sett::const_iterator it = nondets.begin();
+      it != nondets.end(); it++)
+    out << from_expr(ns,"",*it) << " ";
+  out << std::endl;
   out << "forward precondition: " 
       << (fw_precondition.is_nil() ? "not computed" :  
 	  from_expr(ns,"",fw_precondition)) << std::endl;

--- a/src/summarizer/summary.h
+++ b/src/summarizer/summary.h
@@ -26,6 +26,7 @@ class summaryt
 
   typedef std::list<symbol_exprt> var_listt;
   typedef std::set<symbol_exprt> var_sett;
+  typedef std::set<exprt> expr_sett;
 
   summaryt() : 
     fw_precondition(nil_exprt()), 
@@ -41,7 +42,7 @@ class summaryt
 
   var_listt params;
   var_sett globals_in, globals_out;
-
+  expr_sett nondets;
  
   predicatet fw_precondition; // accumulated calling contexts (over-approx)
   //  predicatet fw_postcondition; // we are not projecting that out currently


### PR DESCRIPTION
There's one open issue that I still have to fix: the nondets must be propagated up to the entry function. This requires the renamed nondets to be returned by ssa_inlinert::get_summaries.
But the current version already makes a couple of additional regression tests pass
