### PR TITLE
collecting renamed error assertions - still some of them are missed

### DIFF
--- a/src/domains/incremental_solver.h
+++ b/src/domains/incremental_solver.h
@@ -23,9 +23,9 @@ Author: Peter Schrammel
 //#define NO_ARITH_REFINEMENT
 //#define NON_INCREMENTAL // (experimental)
 
-//#define DISPLAY_FORMULA
-#define DEBUG_FORMULA
-#define DEBUG_OUTPUT
+#define DISPLAY_FORMULA
+//#define DEBUG_FORMULA
+//#define DEBUG_OUTPUT
 
 class incremental_solvert : public messaget
 {

--- a/src/summarizer/summarizer_bw_cex_complete.h
+++ b/src/summarizer/summarizer_bw_cex_complete.h
@@ -48,6 +48,7 @@ class summarizer_bw_cex_completet : public summarizer_bw_cex_baset
   exprt::operandst formula_expr; //for debugging
   exprt::operandst loophead_selects;
   exprt::operandst loop_continues;
+  exprt::operandst renamed_error_assertion;
 
   struct reason_to_checkt {
     function_namet function_name;


### PR DESCRIPTION
This should fail:
../../src/summarizer/2ls cex7/main.c --verbosity 10 --havoc --spurious-check complete --unwind 2 --verbosity 10

but currently it is unknown because the assertion that gets pushed is
!((y#4%1@2 < 4 || !$guard#4%1@2) && (y#4%2@2 < 4 || !$guard#4%2@2))
but it should be 
!((y#4%0@2 < 4 || !$guard#4%0@2) && (y#4%1@2 < 4 || !$guard#4%1@2) && (y#4%2@2 < 4 || !$guard#4%2@2))
