### PR TITLE
assertion renaming in cex_complete fixed

### DIFF
--- a/src/domains/incremental_solver.h
+++ b/src/domains/incremental_solver.h
@@ -23,7 +23,7 @@ Author: Peter Schrammel
 //#define NO_ARITH_REFINEMENT
 //#define NON_INCREMENTAL // (experimental)
 
-//#define DISPLAY_FORMULA
+#define DISPLAY_FORMULA
 //#define DEBUG_FORMULA
 //#define DEBUG_OUTPUT
 

--- a/src/domains/incremental_solver.h
+++ b/src/domains/incremental_solver.h
@@ -23,7 +23,7 @@ Author: Peter Schrammel
 //#define NO_ARITH_REFINEMENT
 //#define NON_INCREMENTAL // (experimental)
 
-#define DISPLAY_FORMULA
+//#define DISPLAY_FORMULA
 //#define DEBUG_FORMULA
 //#define DEBUG_OUTPUT
 
@@ -93,8 +93,10 @@ class incremental_solvert : public messaget
     solver->set_assumptions(whole_formula);
 #endif
 #endif
-#if defined(DEBUG_FORMULA) && defined(DEBUG_OUTPUT)
+#if defined(DEBUG_FORMULA) || defined(DISPLAY_FORMULA)
     decision_proceduret::resultt result = (*solver)();
+#endif
+#if defined(DEBUG_FORMULA) && defined(DEBUG_OUTPUT)
     if(result==decision_proceduret::D_UNSATISFIABLE)
     {
       for(unsigned i=0; i<formula_expr.size(); i++) 
@@ -104,6 +106,8 @@ class incremental_solvert : public messaget
               << from_expr(ns, "", formula_expr[i]) << std::endl;
       }
     }
+#endif
+#if (defined(DEBUG_FORMULA)  && defined(DEBUG_OUTPUT)) || defined(DISPLAY_FORMULA)
     if(result==decision_proceduret::D_SATISFIABLE)
     {
       std::set<symbol_exprt> vars;
@@ -117,7 +121,8 @@ class incremental_solvert : public messaget
       }
     }
     return result;
-#else
+#endif
+#if !defined(DEBUG_FORMULA)  && !defined(DISPLAY_FORMULA)
     return (*solver)();    
 #endif
   }
@@ -198,6 +203,7 @@ static inline incremental_solvert & operator << (
 	      << from_expr(dest.ns,"",src) << std::endl;
   else
       std::cerr << "add_to_solver: " << from_expr(dest.ns,"",src) << std::endl;
+  dest.formula_expr.push_back(src);
 #endif
 
 #ifdef NON_INCREMENTAL

--- a/src/ssa/ssa_inliner.cpp
+++ b/src/ssa/ssa_inliner.cpp
@@ -1193,3 +1193,5 @@ irep_idt ssa_inlinert::get_original_identifier(const symbol_exprt &s)
   return id;
 }
 
+
+

--- a/src/ssa/ssa_inliner.cpp
+++ b/src/ssa/ssa_inliner.cpp
@@ -112,6 +112,7 @@ bool ssa_inlinert::get_inlined(
   exprt::operandst &assert_summaries,
   exprt::operandst &noassert_summaries,
   exprt::operandst &bindings,
+  assertion_mapt &assertion_map,
   int counter,
   bool error_summ)
 {
@@ -120,7 +121,8 @@ bool ssa_inlinert::get_inlined(
 
   bool assertion_flag = get_summaries(fSSA,
     summaryt::call_sitet(fSSA.goto_function.body.instructions.end()),
-    forward,assert_summaries,noassert_summaries,bindings,error_summ);
+    forward,assert_summaries,noassert_summaries,
+    bindings,assertion_map,error_summ);
 
   //bindings
   exprt guard_binding;
@@ -287,14 +289,34 @@ exprt ssa_inlinert::get_summaries(const local_SSAt &SSA)
   return and_exprt(conjunction(bindings),conjunction(summaries));
 }
 
+exprt ssa_inlinert::get_summaries(const local_SSAt &SSA,
+  assertion_mapt &assertion_map)
+{
+  exprt::operandst summaries,bindings;
+  get_summaries(SSA,true,summaries,bindings,assertion_map);
+  return and_exprt(conjunction(bindings),conjunction(summaries));
+}
+
 void ssa_inlinert::get_summaries(const local_SSAt &SSA,
                                  bool forward,
                                  exprt::operandst &summaries,
                                  exprt::operandst &bindings)
 {
+  assertion_mapt assertion_map;
   get_summaries(SSA,
                 summaryt::call_sitet(SSA.goto_function.body.instructions.end()),
-                forward,summaries,summaries,bindings);
+                forward,summaries,summaries,bindings,assertion_map);
+}
+
+void ssa_inlinert::get_summaries(const local_SSAt &SSA,
+                                 bool forward,
+                                 exprt::operandst &summaries,
+                                 exprt::operandst &bindings,
+                                 assertion_mapt &assertion_map)
+{
+  get_summaries(SSA,
+                summaryt::call_sitet(SSA.goto_function.body.instructions.end()),
+                forward,summaries,summaries,bindings,assertion_map);
 }
 
 bool ssa_inlinert::get_summaries(const local_SSAt &SSA,
@@ -305,10 +327,32 @@ bool ssa_inlinert::get_summaries(const local_SSAt &SSA,
                                  exprt::operandst &bindings,
                                  bool error_summ)
 {
+  assertion_mapt assertion_map;
+  return get_summaries(SSA,
+           summaryt::call_sitet(SSA.goto_function.body.instructions.end()),
+         forward,assert_summaries,noassert_summaries,bindings,assertion_map);
+}
+
+bool ssa_inlinert::get_summaries(const local_SSAt &SSA,
+                                 const summaryt::call_sitet &current_call_site,
+                                 bool forward,
+                                 exprt::operandst &assert_summaries,
+                                 exprt::operandst &noassert_summaries,
+                                 exprt::operandst &bindings,
+                                 assertion_mapt &assertion_map,
+                                 bool error_summ)
+{
   bool assertion_flag = false;
   for(local_SSAt::nodest::const_iterator n_it = SSA.nodes.begin();
       n_it != SSA.nodes.end(); n_it++)
   {
+    for(local_SSAt::nodet::assertionst::const_iterator a_it = 
+          n_it->assertions.begin();
+        a_it != n_it->assertions.end(); a_it++)
+    {
+      assertion_map[n_it->location].push_back(*a_it);
+      rename(assertion_map[n_it->location].back(), counter);
+    }
     for(local_SSAt::nodet::function_callst::const_iterator f_it = 
           n_it->function_calls.begin();
         f_it != n_it->function_calls.end(); f_it++)
@@ -327,7 +371,7 @@ bool ssa_inlinert::get_summaries(const local_SSAt &SSA,
         bool new_assertion_flag = 
           get_inlined(SSA,n_it,f_it,
                     forward,assert_summaries,noassert_summaries,
-                    bindings,counter,error_summ);
+                      bindings,assertion_map,counter,error_summ);
         assertion_flag = assertion_flag || new_assertion_flag;
       }
       //get summary
@@ -829,6 +873,8 @@ Function: ssa_inlinert::rename()
 
 irep_idt ssa_inlinert::rename(irep_idt &id, int counter)
 {
+  if(counter<0)
+    return id;
   return id2string(id)+"@"+i2string(counter);
 }
 
@@ -895,13 +941,10 @@ void ssa_inlinert::rename(exprt &expr, int counter)
 {
   if(expr.id()==ID_symbol || expr.id()==ID_nondet_symbol) 
   {
-    std::string id_str = id2string(expr.get(ID_identifier));
-    irep_idt id;
-
-    if(id_str.find('@') != std::string::npos)
-      id = id_str;
-    else
-      id = id_str+"@"+i2string(counter);
+    irep_idt id = expr.get(ID_identifier);
+    std::string id_str = id2string(id);
+    if(id_str.find('@') == std::string::npos)
+      rename(id, counter);
       
     expr.set(ID_identifier,id);
   }

--- a/src/ssa/ssa_inliner.h
+++ b/src/ssa/ssa_inliner.h
@@ -23,10 +23,12 @@ class ssa_inlinert : public messaget
  public:
   explicit ssa_inlinert(summary_dbt &_summary_db, 
                         ssa_dbt &_ssa_db) : 
-      counter(0),
+      counter(-1),
       summary_db(_summary_db),
       ssa_db(_ssa_db)
     {}
+
+  typedef std::map<local_SSAt::locationt, exprt::operandst> assertion_mapt;
 
   void get_guard_binding(const local_SSAt &SSA,
 			 const local_SSAt &fSSA,
@@ -56,8 +58,15 @@ class ssa_inlinert : public messaget
        exprt::operandst &assert_summaries,
        exprt::operandst &noassert_summaries,
 		   exprt::operandst &bindings,
+       assertion_mapt &assertion_map,
 		   int counter,
 		   bool error_summ);
+  void get_summaries(
+       const local_SSAt &SSA,
+		   bool forward,
+		   exprt::operandst &summaries,
+		   exprt::operandst &bindings,
+       assertion_mapt &assertion_map); //TODO: need to explicitly pass the correct counter
   void get_summaries(
        const local_SSAt &SSA,
 		   bool forward,
@@ -71,8 +80,19 @@ class ssa_inlinert : public messaget
        exprt::operandst &noassert_summaries,
        exprt::operandst &bindings,
        bool error_summ = false); //TODO: need to explicitly pass the correct counter
+  bool get_summaries(
+       const local_SSAt &SSA,
+       const summaryt::call_sitet &current_call_site,
+       bool forward,
+       exprt::operandst &assert_summaries,
+       exprt::operandst &noassert_summaries,
+       exprt::operandst &bindings,
+       assertion_mapt &assertion_map,
+       bool error_summ = false); //TODO: need to explicitly pass the correct counter
 
   exprt get_summaries(const local_SSAt &SSA); //TODO: need to explicitly pass the correct counter
+  exprt get_summaries(const local_SSAt &SSA,
+       assertion_mapt &assertion_map); //TODO: need to explicitly pass the correct counter
   
   void replace(local_SSAt &SSA,
 	       local_SSAt::nodest::iterator node,
@@ -146,7 +166,7 @@ class ssa_inlinert : public messaget
   void rename(exprt &expr, int counter);
   
  protected:
-  unsigned counter;
+  int counter;
   summary_dbt &summary_db;
   ssa_dbt &ssa_db;
 

--- a/src/summarizer/cover_goals_ext.cpp
+++ b/src/summarizer/cover_goals_ext.cpp
@@ -179,6 +179,13 @@ void cover_goals_extt::assignment()
     if(property_map[it->first].result==property_checkert::UNKNOWN &&
        solver.l_get(g_it->condition).is_true())
     {
+#if 1
+      solver.pop_context(); //otherwise this would interfere with necessary preconditions
+      summarizer_bw_cex.summarize(g_it->cond_expression);
+      property_map[it->first].result = summarizer_bw_cex.check();
+      solver.new_context();
+#else // THE ASSERTIONS THAT FAIL COULD BE RATHER ARBITRARY SINCE THE FORMULA 
+      //    IS NOT "ROOTED" IN AN INITIAL STATE. 
       assert((g_it->cond_expression).id() == ID_not);
       exprt conjunct_expr = (g_it->cond_expression).op0();
 #if 0
@@ -216,6 +223,7 @@ void cover_goals_extt::assignment()
         property_map[it->first].result = summarizer_bw_cex.check();
         solver.new_context();
       }
+#endif
     }
     if(property_map[it->first].result == property_checkert::FAIL)
     {

--- a/src/summarizer/summarizer_bw_cex_complete.cpp
+++ b/src/summarizer/summarizer_bw_cex_complete.cpp
@@ -287,20 +287,28 @@ find_symbols_sett summarizer_bw_cex_completet::inline_summaries
     }
 
     // if the dependency set is non-empty
-    if(!worknode.dependency_set.empty()){
+    if(!worknode.dependency_set.empty())
+    {
       exprt worknode_info = depnode.node_info;
 
       bool is_error_assertion = false;
-      assert(error_assertion.id()==ID_not);
-      if(error_assertion.op0().id()!=ID_and)
-        is_error_assertion = (worknode_info == error_assertion.op0());
-      else
-        forall_operands(a_it, error_assertion.op0())
-          if(worknode_info == *a_it)
-          {
-            is_error_assertion = true;
-            break;
-          }
+      if(depnode.is_assertion)
+      {
+#if 0
+        std::cout << "assertion: " << from_expr(SSA.ns, "", error_assertion) << std::endl;
+        std::cout << "to check: " << from_expr(SSA.ns, "", worknode_info) << std::endl;
+#endif
+        assert(error_assertion.id()==ID_not);
+        if(error_assertion.op0().id()!=ID_and)
+          is_error_assertion = (worknode_info == error_assertion.op0());
+        else
+          forall_operands(a_it, error_assertion.op0())
+            if(worknode_info == *a_it)
+            {
+              is_error_assertion = true;
+              break;
+            }
+      }
       
       if(worknode.node_index != 0){
         if(!(depnode.is_function_call)){

--- a/src/summarizer/summarizer_bw_cex_complete.cpp
+++ b/src/summarizer/summarizer_bw_cex_complete.cpp
@@ -103,6 +103,17 @@ find_symbols_sett summarizer_bw_cex_completet::inline_summaries
 
   solver << enable_exprs;
 
+  // assumptions must hold
+  for(local_SSAt::nodest::const_iterator 
+	n_it = SSA.nodes.begin(); n_it != SSA.nodes.end(); ++n_it)
+    for(local_SSAt::nodet::assumptionst::const_iterator 
+	  a_it = n_it->assumptions.begin(); a_it != n_it->assumptions.end(); ++a_it)
+    {
+      exprt assumption = *a_it;
+      ssa_inliner.rename(assumption, counter);
+      solver << assumption;
+    }
+
 #ifdef REFINE_ALL
   //TODO: let's just put all loops into the reason
   for(local_SSAt::nodest::iterator n_it = SSA.nodes.begin();

--- a/src/summarizer/summarizer_bw_cex_complete.cpp
+++ b/src/summarizer/summarizer_bw_cex_complete.cpp
@@ -261,7 +261,7 @@ find_symbols_sett summarizer_bw_cex_completet::inline_summaries
       */
       /////////////////////////////////////////////////////////////////////////////////////
 
-#if 0
+#ifdef REFINE_ALL
       //TODO: just put all function calls into reason
       reason[function_name].functions.insert(depnode.location);
 #endif

--- a/src/summarizer/summary_checker_ai.cpp
+++ b/src/summarizer/summary_checker_ai.cpp
@@ -142,7 +142,7 @@ property_checkert::resultt summary_checker_ait::operator()(
 */
 
   std::set<irep_idt> seen_function_calls;
-  property_checkert::resultt result =  check_properties(entry_function, entry_function, seen_function_calls); 
+  property_checkert::resultt result =  check_properties(entry_function, entry_function, seen_function_calls, false); 
   report_statistics();
   return result;
 }

--- a/src/summarizer/summary_checker_base.cpp
+++ b/src/summarizer/summary_checker_base.cpp
@@ -79,7 +79,7 @@ void summary_checker_baset::SSA_dependency_graphs(
     else
       ssa_db.depgraph_create(f_it->first, ns, ssa_inliner, false); // change to true if all functions are to be treated equal
 
-#if 0	  
+#if 1
     ssa_dependency_grapht &ssa_depgraph = ssa_db.get_depgraph(f_it->first);
     ssa_depgraph.output(debug()); debug() << eom;
     std::cout << "output SSA for function: " << f_it->first << "\n";

--- a/src/summarizer/summary_checker_base.cpp
+++ b/src/summarizer/summary_checker_base.cpp
@@ -359,15 +359,9 @@ void summary_checker_baset::check_properties(
       solver << summary.fw_precondition;
   }
 
-  //callee summaries
-  solver << ssa_inliner.get_summaries(SSA);
-
-#if 0
-  //freeze loop head selects
-  exprt::operandst loophead_selects;
-  summarizer_baset::get_loophead_selects(SSA,
-    ssa_unwinder.get(f_it->first),*solver.solver, loophead_selects);
-#endif
+  //callee summaries and inlined functions
+  ssa_inlinert::assertion_mapt assertion_map;
+  solver << ssa_inliner.get_summaries(SSA, assertion_map);
 
   //spuriousness checkers
   summarizer_bw_cex_baset *summarizer_bw_cex = NULL;
@@ -421,61 +415,38 @@ void summary_checker_baset::check_properties(
     all_properties, build_error_trace,
     *summarizer_bw_cex);
 
-#if 0   
-  debug() << "(C) " << from_expr(SSA.ns,"",enabling_expr) << eom;
-#endif
-
-  const goto_programt &goto_program=SSA.goto_function.body;
-
-  for(goto_programt::instructionst::const_iterator
-        i_it=goto_program.instructions.begin();
-      i_it!=goto_program.instructions.end();
-      i_it++)
+  for(ssa_inlinert::assertion_mapt::const_iterator
+        aa_it=assertion_map.begin();
+      aa_it!=assertion_map.end();
+      aa_it++)
   {
-    if(!i_it->is_assert())
-      continue;
-  
-    const source_locationt &location=i_it->source_location;  
-    std::list<local_SSAt::nodest::const_iterator> assertion_nodes;
-    SSA.find_nodes(i_it,assertion_nodes);
-
-    irep_idt property_id = location.get_property_id();
-    
-    if(i_it->guard.is_true())
-    {
-      property_map[property_id].result=PASS;
-      continue;
-    }
+    irep_idt property_id = aa_it->first->source_location.get_property_id();
 
     //do not recheck properties that have already been decided
-    if(property_map[property_id].result!=UNKNOWN) continue; 
+    if(property_map[property_id].result!=UNKNOWN) 
+      continue; 
 
+#if 0
     if(property_id=="") //TODO: some properties do not show up in initialize_property_map
       continue;     
+#endif
 
-    unsigned property_counter = 0;
-    for(std::list<local_SSAt::nodest::const_iterator>::const_iterator
-          n_it=assertion_nodes.begin();
-        n_it!=assertion_nodes.end();
-        n_it++)
+    for(exprt::operandst::const_iterator
+          a_it=aa_it->second.begin();
+        a_it!=aa_it->second.end();
+        a_it++)
     {
-      for(local_SSAt::nodet::assertionst::const_iterator
-            a_it=(*n_it)->assertions.begin();
-          a_it!=(*n_it)->assertions.end();
-          a_it++, property_counter++)
-      {
-        exprt property=*a_it;
+      exprt property=*a_it;
 
-        if(simplify)
-          property=::simplify_expr(property, SSA.ns);
+      if(simplify)
+        property=::simplify_expr(property, SSA.ns);
 
-#if 0 
-        std::cout << "property: " << from_expr(SSA.ns, "", property) << std::endl;
+#if 1
+      std::cout << "property: " << from_expr(SSA.ns, "", property) << std::endl;
 #endif
  
-        property_map[property_id].location = i_it;
-        cover_goals.goal_map[property_id].conjuncts.push_back(property);
-      }
+      property_map[property_id].location = aa_it->first;
+      cover_goals.goal_map[property_id].conjuncts.push_back(property);
     }
   }
     

--- a/src/summarizer/summary_checker_base.cpp
+++ b/src/summarizer/summary_checker_base.cpp
@@ -311,24 +311,7 @@ void summary_checker_baset::check_properties(
   unwindable_local_SSAt &SSA = *f_it->second;
 
   //check whether function has assertions
-  //  SSA.goto_function.body.has_assertion() has become too semantic
-  bool has_assertion = false;
-  for(goto_programt::instructionst::const_iterator
-        i_it=SSA.goto_function.body.instructions.begin();
-      i_it!=SSA.goto_function.body.instructions.end();
-      i_it++)
-  {
-    if(!i_it->is_assert())
-      continue;
-  
-    irep_idt property_id = i_it->source_location.get_property_id();
-    
-    if(i_it->guard.is_true())
-      property_map[property_id].result=PASS;
-    else
-      has_assertion=true;
-  }
-  if(!has_assertion)
+  if(!has_assertion(f_it->first))
     return;
 
   bool all_properties = options.get_bool_option("all-properties");
@@ -631,4 +614,54 @@ void summary_checker_baset::instrument_and_output(goto_modelt &goto_model)
   write_goto_binary(filename, 
                     goto_model.symbol_table, 
                     goto_model.goto_functions, get_message_handler());
+}
+
+/*******************************************************************\
+
+Function: summary_checker_baset::has_assertion
+
+  Inputs:
+
+ Outputs: 
+
+ Purpose: searches recursively for assertions in inlined functions
+
+\*******************************************************************/
+
+bool summary_checker_baset::has_assertion(irep_idt function_name)
+{
+  //  SSA.goto_function.body.has_assertion() has become too semantic
+  bool _has_assertion = false;
+  const local_SSAt &SSA = ssa_db.get(function_name);
+
+  for(local_SSAt::nodest::const_iterator 
+	  n_it = SSA.nodes.begin(); n_it != SSA.nodes.end(); ++n_it)
+  {
+    for(local_SSAt::nodet::assertionst::const_iterator 
+	    a_it = n_it->assertions.begin(); a_it != n_it->assertions.end(); ++a_it)
+    {
+      irep_idt property_id = n_it->location->source_location.get_property_id();
+    
+      if(n_it->location->guard.is_true())
+        property_map[property_id].result=PASS;
+      else
+        _has_assertion=true;
+    }
+    if(!n_it->function_calls_inlined)
+      continue;
+
+    for(local_SSAt::nodet::function_callst::const_iterator 
+	    f_it = n_it->function_calls.begin(); 
+        f_it != n_it->function_calls.end(); ++f_it)
+    {
+      irep_idt fname = to_symbol_expr(f_it->function()).get_identifier();
+      if(ssa_db.functions().find(fname)==ssa_db.functions().end())
+        continue;
+
+      bool new_has_assertion = has_assertion(fname); //recurse
+      _has_assertion = _has_assertion || new_has_assertion;
+    }
+  }
+
+  return _has_assertion;
 }

--- a/src/summarizer/summary_checker_base.cpp
+++ b/src/summarizer/summary_checker_base.cpp
@@ -211,6 +211,7 @@ summary_checker_baset::resultt summary_checker_baset::check_properties(
   {
     ssa_dbt::functionst::const_iterator f_it = 
       ssa_db.functions().find(function_name);
+    assert(f_it != ssa_db.functions().end());
     local_SSAt &SSA = *f_it->second;
 
     // call recursively for all function calls first
@@ -223,10 +224,11 @@ summary_checker_baset::resultt summary_checker_baset::check_properties(
       {
         assert(ff_it->function().id()==ID_symbol); //no function pointers
         irep_idt fname = to_symbol_expr(ff_it->function()).get_identifier();
+        
         //ENHANCE?: can the return value be exploited?
-
-        if(!summary_db.exists(fname) ||	
-           summary_db.get(fname).bw_transformer.is_nil())
+        if(ssa_db.functions().find(fname)!=ssa_db.functions().end() &&
+           (!summary_db.exists(fname) ||	
+            summary_db.get(fname).bw_transformer.is_nil()))
         {
 #if 0
           debug() << "Checking call " << fname << messaget::eom;

--- a/src/summarizer/summary_checker_base.h
+++ b/src/summarizer/summary_checker_base.h
@@ -89,6 +89,9 @@ protected:
   void check_properties(
     const ssa_dbt::functionst::const_iterator f_it,
     irep_idt entry_function="");
+
+  bool has_assertion(irep_idt function_name);
+
 };
 
 #endif

--- a/src/summarizer/summary_checker_base.h
+++ b/src/summarizer/summary_checker_base.h
@@ -84,23 +84,11 @@ protected:
   property_checkert::resultt check_properties(
      irep_idt function_name,
      irep_idt entry_function,
-     std::set<irep_idt> seen_function_calls);
+     std::set<irep_idt> seen_function_calls,
+     bool is_inlined);
   void check_properties(
     const ssa_dbt::functionst::const_iterator f_it,
     irep_idt entry_function="");
-	
-  void error_summary_using_vars(const ssa_dbt::functionst::const_iterator f_it);
-  
-  exprt::operandst get_loophead_selects(
-    const irep_idt &function_name, const local_SSAt &, prop_convt &);
-  bool is_spurious(const exprt::operandst& loophead_selects, 
-		   incremental_solvert&);
-  exprt::operandst get_loop_continues(
-    const irep_idt &function_name, const local_SSAt &, prop_convt &);
-  bool is_fully_unwound(
-    const exprt::operandst& loop_continues,
-    const exprt::operandst& loophead_selects, 
-    incremental_solvert&);
 };
 
 #endif

--- a/src/summarizer/summary_checker_bmc.cpp
+++ b/src/summarizer/summary_checker_bmc.cpp
@@ -68,7 +68,8 @@ property_checkert::resultt summary_checker_bmct::operator()(
 
     //check
     std::set<irep_idt> seen_function_calls;
-    result =  check_properties(entry_function, entry_function, seen_function_calls); 
+    result =  check_properties(entry_function, entry_function, 
+                               seen_function_calls, false); 
 
     //result
     if(result == property_checkert::PASS) 

--- a/src/summarizer/summary_checker_kind.cpp
+++ b/src/summarizer/summary_checker_kind.cpp
@@ -69,7 +69,7 @@ property_checkert::resultt summary_checker_kindt::operator()(
     //check
     std::set<irep_idt> seen_function_calls;
     result =  check_properties(entry_function, entry_function, 
-                               seen_function_calls); 
+                               seen_function_calls, false); 
 
     //do static analysis and check again
     if(result == property_checkert::UNKNOWN &&
@@ -80,7 +80,7 @@ property_checkert::resultt summary_checker_kindt::operator()(
       summarize(goto_model);
       std::set<irep_idt> seen_function_calls;
       result =  check_properties(entry_function, entry_function, 
-                                 seen_function_calls); 
+                                 seen_function_calls, false); 
     }
 
     //result


### PR DESCRIPTION
Now everything should be there to enable refinement by inlining.
The kiki regressions work fine (besides pointer7).

In modular:
1. dependency graph doesn't seem to rename anymore and produce the correct bindings.
I had to do some changes to ssa_inliner that affect the adding of @ suffixes (in particular, no @ suffix is added when counter is negative), but it is unclear to me how that completely stops the dependency graph from doing the renaming and why the bindings do not appear in the formula anymore:

run 
../../src/summarizer/2ls nocex1/main.c --havoc --spurious-check complete --verbosity 10
to look at the formula that is pushed into the solver
1. modular/induction4, 5 and 8, kind6, loop25, nested11 and 12, scope1 fail because of
   This will re-appear as soon as 1. is fixed.

check graph of the function: main
2ls: summarizer_bw_cex_complete.cpp:508: virtual find_symbols_sett summarizer_bw_cex_completet::inline_summaries(const function_namet&, find_symbols_sett&, int): Assertion `false' failed.
Aborted (core dumped)
