### PR TITLE
inlined functions must not contain negated assertions; assertions are…

### DIFF
--- a/src/domains/incremental_solver.h
+++ b/src/domains/incremental_solver.h
@@ -23,7 +23,7 @@ Author: Peter Schrammel
 //#define NO_ARITH_REFINEMENT
 //#define NON_INCREMENTAL // (experimental)
 
-#define DISPLAY_FORMULA
+//#define DISPLAY_FORMULA
 //#define DEBUG_FORMULA
 //#define DEBUG_OUTPUT
 
@@ -154,7 +154,7 @@ class incremental_solvert : public messaget
   //for debugging
   bvt formula;
   exprt::operandst formula_expr;
-  void debug_add_to_formula(const exprt &expr);
+  void debug_add_to_formula(const exprt &expr, exprt activation=nil_exprt());
 
   //context assumption literals
   bvt activation_literals;
@@ -217,8 +217,8 @@ static inline incremental_solvert & operator << (
     *dest.solver << src;
 #else
   if(!dest.activation_literals.empty())
-    dest.debug_add_to_formula(
-      or_exprt(src,literal_exprt(!dest.activation_literals.back())));
+    dest.debug_add_to_formula(src,
+                              literal_exprt(!dest.activation_literals.back()));
   else 
     dest.debug_add_to_formula(src);
 #endif

--- a/src/ssa/local_ssa.cpp
+++ b/src/ssa/local_ssa.cpp
@@ -1907,7 +1907,7 @@ exprt local_SSAt::get_enabling_exprs() const
 {
   exprt result = conjunction(enabling_exprs);
 
-#if 1
+#if 0
   std::cout << "current enabling expr:" << from_expr(ns, "", result) << "\n";
 #endif
 

--- a/src/ssa/ssa_inliner.cpp
+++ b/src/ssa/ssa_inliner.cpp
@@ -164,8 +164,10 @@ bool ssa_inlinert::get_inlined(
     for(local_SSAt::nodet::assertionst::const_iterator a_it =
           fnode.assertions.begin(); a_it!=fnode.assertions.end(); a_it++)
     {
+#if 0
       assert_summaries.push_back(*a_it);
       rename(assert_summaries.back(), counter);
+#endif
       assertion_flag = true;
     }
   }

--- a/src/summarizer/summarizer_bw_cex_complete.cpp
+++ b/src/summarizer/summarizer_bw_cex_complete.cpp
@@ -304,7 +304,7 @@ find_symbols_sett summarizer_bw_cex_completet::inline_summaries
       bool is_error_assertion = false;
       if(depnode.is_assertion)
       {
-#if 1
+#if 0
         std::cout << "assertion: " << from_expr(SSA.ns, "", error_assertion) << std::endl;
         std::cout << "to check: " << from_expr(SSA.ns, "", worknode_info) << std::endl;
 #endif

--- a/src/summarizer/summary_checker_base.cpp
+++ b/src/summarizer/summary_checker_base.cpp
@@ -79,7 +79,7 @@ void summary_checker_baset::SSA_dependency_graphs(
     else
       ssa_db.depgraph_create(f_it->first, ns, ssa_inliner, false); // change to true if all functions are to be treated equal
 
-#if 1
+#if 0
     ssa_dependency_grapht &ssa_depgraph = ssa_db.get_depgraph(f_it->first);
     ssa_depgraph.output(debug()); debug() << eom;
     std::cout << "output SSA for function: " << f_it->first << "\n";
@@ -442,7 +442,7 @@ void summary_checker_baset::check_properties(
         property=::simplify_expr(property, SSA.ns);
 
 #if 1
-      std::cout << "property: " << from_expr(SSA.ns, "", property) << std::endl;
+      debug() << "property: " << from_expr(SSA.ns, "", property) << eom;
 #endif
  
       property_map[property_id].location = aa_it->first;


### PR DESCRIPTION
induction4, 5, kind6, nested11, s3_clnt_1, and scope1 
fail because of dep graph assertion failure "check graph of the function"
